### PR TITLE
feat: IDLアノテーションによる検証付きC++ Type Adapter生成機能 (rosidl_generator_validated_cpp)

### DIFF
--- a/rosidl_generator_validated_cpp/CMakeLists.txt
+++ b/rosidl_generator_validated_cpp/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+project(rosidl_generator_validated_cpp)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(rosidl_cmake REQUIRED)
+
+# Install Python package
+ament_python_install_package(${PROJECT_NAME})
+
+# Install CLI script
+install(PROGRAMS
+  bin/rosidl_generator_validated_cpp
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Install resource (templates)
+install(DIRECTORY resource/
+  DESTINATION share/${PROJECT_NAME}/resource
+)
+
+# Install cmake files
+install(FILES
+  cmake/rosidl_generator_validated_cpp_generate_interfaces.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake
+)
+
+# Configure and install extras file
+set(PYTHON_INSTALL_DIR "lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages")
+configure_file(
+  cmake/rosidl_generator_validated_cpp-extras.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/rosidl_generator_validated_cpp-extras.cmake
+  @ONLY
+)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/rosidl_generator_validated_cpp-extras.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake
+)
+
+ament_package(
+  CONFIG_EXTRAS
+    "cmake/rosidl_generator_validated_cpp-extras.cmake.in"
+)

--- a/rosidl_generator_validated_cpp/bin/rosidl_generator_validated_cpp
+++ b/rosidl_generator_validated_cpp/bin/rosidl_generator_validated_cpp
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from rosidl_generator_validated_cpp import generate_validated_cpp
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate validated C++ type adapters from ROS interfaces.')
+    parser.add_argument(
+        '--generator-arguments-file',
+        required=True,
+        help='The path to the generator arguments file')
+    args = parser.parse_args()
+
+    try:
+        generate_validated_cpp(args.generator_arguments_file)
+        return 0
+    except Exception as e:
+        print(f'Error: {e}', file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/rosidl_generator_validated_cpp/cmake/rosidl_generator_validated_cpp-extras.cmake.in
+++ b/rosidl_generator_validated_cpp/cmake/rosidl_generator_validated_cpp-extras.cmake.in
@@ -1,0 +1,24 @@
+# generated from rosidl_generator_validated_cpp/cmake/rosidl_generator_validated_cpp-extras.cmake.in
+
+macro(rosidl_generator_validated_cpp_extras BIN GENERATOR_FILES TEMPLATE_DIR)
+  find_package(ament_cmake_core QUIET REQUIRED)
+  ament_register_extension(
+    "rosidl_generate_idl_interfaces"
+    "rosidl_generator_validated_cpp"
+    "rosidl_generator_validated_cpp_generate_interfaces.cmake")
+
+  normalize_path(BIN "${BIN}")
+  set(rosidl_generator_validated_cpp_BIN "${BIN}")
+
+  normalize_path(GENERATOR_FILES "${GENERATOR_FILES}")
+  set(rosidl_generator_validated_cpp_GENERATOR_FILES "${GENERATOR_FILES}")
+
+  normalize_path(TEMPLATE_DIR "${TEMPLATE_DIR}")
+  set(rosidl_generator_validated_cpp_TEMPLATE_DIR "${TEMPLATE_DIR}")
+endmacro()
+
+rosidl_generator_validated_cpp_extras(
+  "${rosidl_generator_validated_cpp_DIR}/../../../lib/rosidl_generator_validated_cpp/rosidl_generator_validated_cpp"
+  "${rosidl_generator_validated_cpp_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_generator_validated_cpp/__init__.py"
+  "${rosidl_generator_validated_cpp_DIR}/../resource"
+)

--- a/rosidl_generator_validated_cpp/cmake/rosidl_generator_validated_cpp_generate_interfaces.cmake
+++ b/rosidl_generator_validated_cpp/cmake/rosidl_generator_validated_cpp_generate_interfaces.cmake
@@ -1,0 +1,125 @@
+# Copyright 2024 Hans
+#
+# Licensed under the Apache License, Version 2.0
+
+find_package(rosidl_cmake REQUIRED)
+find_package(rosidl_generator_cpp REQUIRED)
+
+set(_output_path
+  "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_validated_cpp/${PROJECT_NAME}")
+set(_generated_headers "")
+
+foreach(_abs_idl_file ${rosidl_generate_interfaces_ABS_IDL_FILES})
+  get_filename_component(_parent_folder "${_abs_idl_file}" DIRECTORY)
+  get_filename_component(_parent_folder "${_parent_folder}" NAME)
+  get_filename_component(_idl_name "${_abs_idl_file}" NAME_WE)
+  string_camel_case_to_lower_case_underscore("${_idl_name}" _header_name)
+
+  list(APPEND _generated_headers
+    "${_output_path}/${_parent_folder}/validated/${_header_name}__validated.hpp"
+  )
+endforeach()
+
+set(_dependency_files "")
+set(_dependencies "")
+foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
+  foreach(_idl_file ${${_pkg_name}_IDL_FILES})
+    rosidl_find_package_idl(_abs_idl_file "${_pkg_name}" "${_idl_file}")
+    list(APPEND _dependency_files "${_abs_idl_file}")
+    list(APPEND _dependencies "${_pkg_name}:${_abs_idl_file}")
+  endforeach()
+endforeach()
+
+set(target_dependencies
+  "${rosidl_generator_validated_cpp_BIN}"
+  ${rosidl_generator_validated_cpp_GENERATOR_FILES}
+  "${rosidl_generator_validated_cpp_TEMPLATE_DIR}/validated_idl.hpp.em"
+  ${rosidl_generate_interfaces_ABS_IDL_FILES}
+  ${_dependency_files})
+
+foreach(dep ${target_dependencies})
+  if(NOT EXISTS "${dep}")
+    message(FATAL_ERROR "Target dependency '${dep}' does not exist")
+  endif()
+endforeach()
+
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_validated_cpp__arguments.json")
+rosidl_write_generator_arguments(
+  "${generator_arguments_file}"
+  PACKAGE_NAME "${PROJECT_NAME}"
+  IDL_TUPLES "${rosidl_generate_interfaces_IDL_TUPLES}"
+  ROS_INTERFACE_DEPENDENCIES "${_dependencies}"
+  OUTPUT_DIR "${_output_path}"
+  TEMPLATE_DIR "${rosidl_generator_validated_cpp_TEMPLATE_DIR}"
+  TARGET_DEPENDENCIES ${target_dependencies}
+)
+
+cmake_minimum_required(VERSION 3.20)
+cmake_policy(SET CMP0094 NEW)
+set(Python3_FIND_UNVERSIONED_NAMES FIRST)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+add_custom_command(
+  OUTPUT ${_generated_headers}
+  COMMAND Python3::Interpreter
+  ARGS ${rosidl_generator_validated_cpp_BIN}
+  --generator-arguments-file "${generator_arguments_file}"
+  DEPENDS ${target_dependencies}
+  COMMENT "Generating validated C++ type adapters"
+  VERBATIM
+)
+
+set(_target_suffix "__rosidl_generator_validated_cpp")
+
+add_custom_target(
+  ${rosidl_generate_interfaces_TARGET}__validated_cpp
+  DEPENDS
+  ${_generated_headers}
+)
+
+# Depend on the standard C++ generator completing first
+add_dependencies(
+  ${rosidl_generate_interfaces_TARGET}__validated_cpp
+  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp)
+
+add_library(${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE)
+target_compile_features(${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE cxx_std_17)
+add_library(${PROJECT_NAME}::${rosidl_generate_interfaces_TARGET}${_target_suffix} ALIAS
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+
+target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_validated_cpp>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
+# Link to the standard rosidl_generator_cpp target for the base message types
+target_link_libraries(
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix} INTERFACE
+  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp)
+
+add_dependencies(
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_interfaces_TARGET}__validated_cpp)
+
+add_dependencies(
+  ${rosidl_generate_interfaces_TARGET}
+  ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+
+if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
+  install(
+    DIRECTORY ${_output_path}/
+    DESTINATION "include/${PROJECT_NAME}/${PROJECT_NAME}"
+    PATTERN "*.hpp"
+  )
+
+  ament_export_targets(export_${rosidl_generate_interfaces_TARGET}${_target_suffix})
+  rosidl_export_typesupport_targets(${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}${_target_suffix})
+
+  install(
+    TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    EXPORT export_${rosidl_generate_interfaces_TARGET}${_target_suffix}
+  )
+endif()

--- a/rosidl_generator_validated_cpp/package.xml
+++ b/rosidl_generator_validated_cpp/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosidl_generator_validated_cpp</name>
+  <version>0.1.0</version>
+  <description>
+    rosidl generator for validated C++ type adapters.
+    Generates Type Adapter classes with validation based on IDL annotations (@range, @min, @max).
+  </description>
+  <maintainer email="hans@example.com">Hans</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <build_depend>rosidl_cmake</build_depend>
+
+  <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
+
+  <depend>rosidl_generator_cpp</depend>
+  <depend>rosidl_parser</depend>
+  <depend>rosidl_pycommon</depend>
+
+  <exec_depend>python3-empy</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_generator_validated_cpp/resource/validated_idl.hpp.em
+++ b/rosidl_generator_validated_cpp/resource/validated_idl.hpp.em
@@ -1,0 +1,247 @@
+@# Generation template for validated C++ type adapters
+@#
+@# Context variables:
+@#   - package_name (str): Name of the package
+@#   - interface_path (Path): Path to the IDL file relative to package
+@#   - content (IdlContent): Parsed IDL content
+@#   - get_validation_info (function): Get validation info from member
+@#   - get_cpp_type (function): Get C++ type string
+@#   - is_numeric_type (function): Check if type is numeric
+@#   - is_array_type (function): Check if type is array
+@#   - is_sequence_type (function): Check if type is sequence
+@#   - is_string_type (function): Check if type is string
+@#   - is_bounded_string (function): Check if type is bounded string
+@#   - get_string_bound (function): Get string bound
+@#   - get_array_size (function): Get array size
+@{
+from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
+from rosidl_parser.definition import Message
+
+# Get message from content
+messages = list(content.get_elements_of_type(Message))
+}@
+@[for message in messages]@
+@{
+struct_name = message.structure.namespaced_type.name
+header_name = convert_camel_case_to_lower_case_underscore(struct_name)
+include_guard = (package_name + '__MSG__VALIDATED__' + struct_name + '__VALIDATED_HPP_').upper()
+}@
+// Copyright 2024 Hans
+// Licensed under the Apache License, Version 2.0
+
+// Auto-generated validated type adapter for @(package_name)::msg::@(struct_name)
+// DO NOT EDIT MANUALLY
+
+#ifndef @(include_guard)
+#define @(include_guard)
+
+#include <array>
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "rclcpp/type_adapter.hpp"
+#include "@(package_name)/msg/@(header_name).hpp"
+
+namespace @(package_name)
+{
+namespace msg
+{
+namespace validated
+{
+
+/// Exception thrown when validation fails
+class ValidationError : public std::runtime_error
+{
+public:
+  explicit ValidationError(const std::string & message)
+  : std::runtime_error(message) {}
+};
+
+/// Validated wrapper for @(struct_name)
+///
+/// This class wraps the ROS message type and provides validation
+/// based on IDL annotations (@range, @@min, @@max).
+/// Validation is performed when converting to ROS message (e.g., on publish).
+struct @(struct_name)Validated
+{
+  using ROSMessage = @(package_name)::msg::@(struct_name);
+
+  // Member variables (same as ROS message)
+@[for member in message.structure.members]@
+@{
+cpp_type = get_cpp_type(member.type)
+validation = get_validation_info(member)
+unit_comment = ''
+if validation['unit']:
+    unit_comment = '  // unit: ' + validation['unit']
+}@
+  @(cpp_type) @(member.name){};@(unit_comment)
+@[end for]@
+
+  /// Default constructor
+  @(struct_name)Validated() = default;
+
+  /// Constructor from ROS message
+  explicit @(struct_name)Validated(const ROSMessage & msg)
+  {
+@[for member in message.structure.members]@
+    @(member.name) = msg.@(member.name);
+@[end for]@
+  }
+
+  /// Validate all fields and throw ValidationError if invalid
+  ///
+  /// @@throws ValidationError if any field is out of range
+  void validate() const
+  {
+@[for member in message.structure.members]@
+@{
+validation = get_validation_info(member)
+is_array = is_array_type(member.type)
+is_seq = is_sequence_type(member.type)
+is_numeric = is_numeric_type(member.type)
+is_str = is_string_type(member.type)
+}@
+@[  if validation['has_range'] and is_numeric]@
+@[    if is_array or is_seq]@
+    // Validate @(member.name) (array/sequence elements)
+    for (size_t i = 0; i < @(member.name).size(); ++i) {
+@[      if validation['min_value'] is not None]@
+      if (@(member.name)[i] < @(validation['min_value'])) {
+        std::ostringstream oss;
+        oss << "Field '@(member.name)[" << i << "]' value " << @(member.name)[i]
+            << " is below minimum @(validation['min_value'])";
+        throw ValidationError(oss.str());
+      }
+@[      end if]@
+@[      if validation['max_value'] is not None]@
+      if (@(member.name)[i] > @(validation['max_value'])) {
+        std::ostringstream oss;
+        oss << "Field '@(member.name)[" << i << "]' value " << @(member.name)[i]
+            << " exceeds maximum @(validation['max_value'])";
+        throw ValidationError(oss.str());
+      }
+@[      end if]@
+    }
+@[    else]@
+    // Validate @(member.name)
+@[      if validation['min_value'] is not None]@
+    if (@(member.name) < @(validation['min_value'])) {
+      std::ostringstream oss;
+      oss << "Field '@(member.name)' value " << @(member.name)
+          << " is below minimum @(validation['min_value'])";
+      throw ValidationError(oss.str());
+    }
+@[      end if]@
+@[      if validation['max_value'] is not None]@
+    if (@(member.name) > @(validation['max_value'])) {
+      std::ostringstream oss;
+      oss << "Field '@(member.name)' value " << @(member.name)
+          << " exceeds maximum @(validation['max_value'])";
+      throw ValidationError(oss.str());
+    }
+@[      end if]@
+@[    end if]@
+@[  end if]@
+@[  if validation['has_string_length']]@
+    // Validate @(member.name) string length
+    if (@(member.name).length() > @(validation['max_string_length'])) {
+      std::ostringstream oss;
+      oss << "Field '@(member.name)' length " << @(member.name).length()
+          << " exceeds maximum @(validation['max_string_length'])";
+      throw ValidationError(oss.str());
+    }
+@[  end if]@
+@[end for]@
+  }
+
+  /// Check if all fields are valid (non-throwing)
+  ///
+  /// @@return true if all fields pass validation
+  bool is_valid() const noexcept
+  {
+    try {
+      validate();
+      return true;
+    } catch (const ValidationError &) {
+      return false;
+    }
+  }
+
+  /// Create from ROS message (no validation)
+  ///
+  /// @@param msg The ROS message to copy from
+  /// @@return A new validated wrapper instance
+  static @(struct_name)Validated from_ros_message(const ROSMessage & msg)
+  {
+    return @(struct_name)Validated(msg);
+  }
+
+  /// Convert to ROS message with validation
+  ///
+  /// @@return The ROS message
+  /// @@throws ValidationError if any field is out of range
+  ROSMessage to_ros_message() const
+  {
+    validate();  // Validate before conversion
+    ROSMessage msg;
+@[for member in message.structure.members]@
+    msg.@(member.name) = @(member.name);
+@[end for]@
+    return msg;
+  }
+
+  /// Convert to ROS message without validation
+  ///
+  /// @@return The ROS message (may contain invalid values)
+  ROSMessage to_ros_message_unchecked() const noexcept
+  {
+    ROSMessage msg;
+@[for member in message.structure.members]@
+    msg.@(member.name) = @(member.name);
+@[end for]@
+    return msg;
+  }
+};
+
+}  // namespace validated
+}  // namespace msg
+}  // namespace @(package_name)
+
+// Type Adapter specialization for rclcpp
+template<>
+struct rclcpp::TypeAdapter<
+  @(package_name)::msg::validated::@(struct_name)Validated,
+  @(package_name)::msg::@(struct_name)>
+{
+  using is_specialized = std::true_type;
+  using custom_type = @(package_name)::msg::validated::@(struct_name)Validated;
+  using ros_message_type = @(package_name)::msg::@(struct_name);
+
+  /// Convert from custom type to ROS message (validation happens here)
+  static void convert_to_ros_message(
+    const custom_type & source,
+    ros_message_type & destination)
+  {
+    destination = source.to_ros_message();  // Validation inside
+  }
+
+  /// Convert from ROS message to custom type (no validation)
+  static void convert_to_custom(
+    const ros_message_type & source,
+    custom_type & destination)
+  {
+    destination = custom_type::from_ros_message(source);
+  }
+};
+
+// Convenience type alias
+using @(struct_name)Adapted = rclcpp::TypeAdapter<
+  @(package_name)::msg::validated::@(struct_name)Validated,
+  @(package_name)::msg::@(struct_name)>;
+
+#endif  // @(include_guard)
+@[end for]@

--- a/rosidl_generator_validated_cpp/rosidl_generator_validated_cpp/__init__.py
+++ b/rosidl_generator_validated_cpp/rosidl_generator_validated_cpp/__init__.py
@@ -1,0 +1,221 @@
+# Copyright 2024 Hans
+#
+# Licensed under the Apache License, Version 2.0
+
+"""Generate validated C++ type adapters from ROS interfaces."""
+
+from rosidl_parser.definition import AbstractNestedType
+from rosidl_parser.definition import AbstractSequence
+from rosidl_parser.definition import AbstractString
+from rosidl_parser.definition import AbstractWString
+from rosidl_parser.definition import Array
+from rosidl_parser.definition import BasicType
+from rosidl_parser.definition import BoundedString
+from rosidl_parser.definition import NamespacedType
+from rosidl_pycommon import generate_files
+
+
+def generate_validated_cpp(generator_arguments_file):
+    """Generate validated C++ type adapters.
+
+    Args:
+        generator_arguments_file: Path to JSON file with generator arguments.
+
+    Returns:
+        List of generated files.
+    """
+    mapping = {
+        'validated_idl.hpp.em': 'validated/%s__validated.hpp',
+    }
+
+    additional_context = {
+        'get_validation_info': get_validation_info,
+        'get_cpp_type': get_cpp_type,
+        'is_numeric_type': is_numeric_type,
+        'is_array_type': is_array_type,
+        'is_sequence_type': is_sequence_type,
+        'is_string_type': is_string_type,
+        'is_bounded_string': is_bounded_string,
+        'get_string_bound': get_string_bound,
+        'get_array_size': get_array_size,
+    }
+
+    return generate_files(
+        generator_arguments_file, mapping,
+        additional_context=additional_context,
+        post_process_callback=prefix_with_bom_if_necessary)
+
+
+def prefix_with_bom_if_necessary(content):
+    """Add BOM if content contains non-ASCII characters."""
+    try:
+        content.encode('ASCII')
+    except UnicodeError:
+        prefix = '\ufeff' + \
+            '// NOLINT: This file starts with a BOM ' + \
+            'since it contain non-ASCII characters\n'
+        content = prefix + content
+    return content
+
+
+# C++ type mapping (simplified, without allocator)
+MSG_TYPE_TO_CPP = {
+    'boolean': 'bool',
+    'octet': 'unsigned char',
+    'char': 'unsigned char',
+    'wchar': 'char16_t',
+    'float': 'float',
+    'double': 'double',
+    'long double': 'long double',
+    'uint8': 'uint8_t',
+    'int8': 'int8_t',
+    'uint16': 'uint16_t',
+    'int16': 'int16_t',
+    'uint32': 'uint32_t',
+    'int32': 'int32_t',
+    'uint64': 'uint64_t',
+    'int64': 'int64_t',
+    'string': 'std::string',
+    'wstring': 'std::u16string',
+}
+
+
+def get_cpp_type(type_):
+    """Convert rosidl type to C++ type string."""
+    if isinstance(type_, AbstractNestedType):
+        value_type = type_.value_type
+    else:
+        value_type = type_
+
+    if isinstance(value_type, BasicType):
+        cpp_type = MSG_TYPE_TO_CPP[value_type.typename]
+    elif isinstance(value_type, AbstractString):
+        cpp_type = 'std::string'
+    elif isinstance(value_type, AbstractWString):
+        cpp_type = 'std::u16string'
+    elif isinstance(value_type, NamespacedType):
+        cpp_type = '::'.join(value_type.namespaced_name())
+    else:
+        cpp_type = 'unknown'
+
+    if isinstance(type_, Array):
+        return f'std::array<{cpp_type}, {type_.size}>'
+    elif isinstance(type_, AbstractSequence):
+        return f'std::vector<{cpp_type}>'
+    else:
+        return cpp_type
+
+
+def is_numeric_type(type_):
+    """Check if type is a numeric type that can have range validation."""
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    if isinstance(type_, BasicType):
+        return type_.typename not in ('boolean', 'octet', 'char', 'wchar')
+    return False
+
+
+def is_array_type(type_):
+    """Check if type is a fixed-size array."""
+    return isinstance(type_, Array)
+
+
+def is_sequence_type(type_):
+    """Check if type is a sequence (dynamic array)."""
+    return isinstance(type_, AbstractSequence)
+
+
+def is_string_type(type_):
+    """Check if type is a string."""
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    return isinstance(type_, (AbstractString, AbstractWString))
+
+
+def is_bounded_string(type_):
+    """Check if type is a bounded string."""
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    return isinstance(type_, BoundedString)
+
+
+def get_string_bound(type_):
+    """Get the maximum length of a bounded string."""
+    if isinstance(type_, AbstractNestedType):
+        type_ = type_.value_type
+    if isinstance(type_, BoundedString):
+        return type_.maximum_size
+    return None
+
+
+def get_array_size(type_):
+    """Get the size of a fixed-size array."""
+    if isinstance(type_, Array):
+        return type_.size
+    return None
+
+
+def get_validation_info(member):
+    """Extract validation information from IDL annotations.
+
+    Supported annotations:
+        @range(min=X, max=Y) - Range validation
+        @min(value=X) or @min(X) - Minimum value
+        @max(value=X) or @max(X) - Maximum value
+        @unit(value="X") or @unit("X") - Unit annotation
+
+    Args:
+        member: A rosidl_parser.definition.Member object.
+
+    Returns:
+        A dictionary with validation information.
+    """
+    info = {
+        'has_range': False,
+        'min_value': None,
+        'max_value': None,
+        'unit': None,
+        'has_string_length': False,
+        'max_string_length': None,
+    }
+
+    # @range(min=X, max=Y) annotation
+    if member.has_annotation('range'):
+        value = member.get_annotation_value('range')
+        info['has_range'] = True
+        if isinstance(value, dict):
+            info['min_value'] = value.get('min')
+            info['max_value'] = value.get('max')
+
+    # @min(value=X) or @min(X) annotation
+    if member.has_annotation('min'):
+        info['has_range'] = True
+        value = member.get_annotation_value('min')
+        if isinstance(value, dict):
+            info['min_value'] = value.get('value')
+        else:
+            info['min_value'] = value
+
+    # @max(value=X) or @max(X) annotation
+    if member.has_annotation('max'):
+        info['has_range'] = True
+        value = member.get_annotation_value('max')
+        if isinstance(value, dict):
+            info['max_value'] = value.get('value')
+        else:
+            info['max_value'] = value
+
+    # @unit(value="X") or @unit("X") annotation
+    if member.has_annotation('unit'):
+        value = member.get_annotation_value('unit')
+        if isinstance(value, dict):
+            info['unit'] = value.get('value')
+        else:
+            info['unit'] = str(value)
+
+    # Bounded string check
+    if is_bounded_string(member.type):
+        info['has_string_length'] = True
+        info['max_string_length'] = get_string_bound(member.type)
+
+    return info

--- a/sample_interfaces/CMakeLists.txt
+++ b/sample_interfaces/CMakeLists.txt
@@ -9,19 +9,41 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -g)
 endif()
 
-find_package(ament_cmake_auto REQUIRED)
-find_package(rosidl_cmake REQUIRED)
+find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(rosidl_generator_validated_cpp REQUIRED)
+find_package(rclcpp REQUIRED)
 
-ament_auto_add_executable(${PROJECT_NAME}_node src/node.cpp)
-ament_auto_add_executable(${PROJECT_NAME}_node2 src/node.cpp)
-ament_auto_add_executable(${PROJECT_NAME}_node_no_targets src/node_no_targets.cpp)
-
-rosidl_auto_generate_interfaces(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_node2)
-
-target_link_libraries(${PROJECT_NAME}_node_no_targets
-  ${PROJECT_NAME}__rosidl_typesupport_cpp
+# Generate interfaces from msg and idl files
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Test.msg"
+  "msg/TestA.msg"
+  "msg/TestB.msg"
+  "msg/SensorData.idl"
 )
 
-ament_auto_package()
+# Build executables
+add_executable(${PROJECT_NAME}_node src/node.cpp)
+ament_target_dependencies(${PROJECT_NAME}_node rclcpp)
+
+add_executable(${PROJECT_NAME}_node2 src/node.cpp)
+ament_target_dependencies(${PROJECT_NAME}_node2 rclcpp)
+
+add_executable(${PROJECT_NAME}_node_no_targets src/node_no_targets.cpp)
+ament_target_dependencies(${PROJECT_NAME}_node_no_targets rclcpp)
+
+# Link generated interfaces to executables
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(${PROJECT_NAME}_node ${cpp_typesupport_target})
+target_link_libraries(${PROJECT_NAME}_node2 ${cpp_typesupport_target})
+target_link_libraries(${PROJECT_NAME}_node_no_targets ${cpp_typesupport_target})
+
+# Install executables
+install(TARGETS
+  ${PROJECT_NAME}_node
+  ${PROJECT_NAME}_node2
+  ${PROJECT_NAME}_node_no_targets
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/sample_interfaces/README.md
+++ b/sample_interfaces/README.md
@@ -1,0 +1,221 @@
+# sample_interfaces
+
+ROS 2 インターフェース（メッセージ、サービス、アクション）の自動生成を示すサンプルパッケージです。
+
+`rosidl_auto_generate_interfaces` マクロを使用して、従来の `rosidl_generate_interfaces` よりも簡潔にインターフェースを生成できます。
+
+## Before/After 比較
+
+### ケース1: インターフェース生成のみ（ノードなし）
+
+他のパッケージから利用されるインターフェース専用パッケージの場合。
+
+#### Before（従来方式）
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_interfaces)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Test.msg"
+  "msg/TestA.msg"
+  "msg/TestB.msg"
+  DEPENDENCIES std_msgs
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()
+```
+
+#### After（自動方式）
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_interfaces)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+
+rosidl_auto_generate_interfaces(ADD_LINTER_TESTS)
+
+ament_package()
+```
+
+---
+
+### ケース2: インターフェース + ノード（同一パッケージ）
+
+インターフェースを定義し、同じパッケージ内のノードで使用する場合。
+
+#### Before（従来方式）
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_interfaces)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rclcpp REQUIRED)
+
+# メッセージファイルを手動で列挙
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Test.msg"
+  "msg/TestA.msg"
+  "msg/TestB.msg"
+)
+
+# 実行ファイルを作成
+add_executable(my_node src/node.cpp)
+ament_target_dependencies(my_node rclcpp)
+
+# 型サポートターゲットを手動で取得してリンク
+rosidl_get_typesupport_target(cpp_typesupport_target
+  ${PROJECT_NAME} rosidl_typesupport_cpp)
+target_link_libraries(my_node ${cpp_typesupport_target})
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()
+```
+
+#### After（自動方式）
+
+```cmake
+cmake_minimum_required(VERSION 3.12)
+project(my_interfaces)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rclcpp REQUIRED)
+
+# 実行ファイルを作成
+add_executable(my_node src/node.cpp)
+ament_target_dependencies(my_node rclcpp)
+
+# msg/, srv/, action/ を自動検出し、指定ターゲットへ自動リンク
+rosidl_auto_generate_interfaces(TARGETS my_node)
+
+ament_package()
+```
+
+---
+
+## 主な違い
+
+| 項目 | Before（従来方式） | After（自動方式） |
+|------|-------------------|------------------|
+| ファイル列挙 | 手動で全ファイル指定 | `msg/`, `srv/`, `action/` を自動検出 |
+| 依存関係 | 手動で `find_package` | `ament_auto_find_build_dependencies()` |
+| ターゲットリンク | `rosidl_get_typesupport_target` + `target_link_libraries` | `TARGETS` 引数で自動 |
+| パッケージ処理 | `ament_package()` | `ament_auto_package()` |
+| 行数 | 約20行 | 約10行 |
+
+## package.xml の要件
+
+`rosidl_auto_generate_interfaces` を使用するには、以下の依存関係が必須です：
+
+```xml
+<?xml version="1.0"?>
+<package format="3">
+  <name>my_interfaces</name>
+  <!-- ... -->
+
+  <!-- 必須: ビルドツール依存 -->
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <!-- 必須: 実行時依存 -->
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <!-- 必須: インターフェースパッケージグループへの所属 -->
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+```
+
+## 使い方
+
+### パターン1: TARGETS引数あり（推奨）
+
+特定のターゲットに型サポートライブラリを自動リンク：
+
+```cmake
+ament_auto_add_executable(node1 src/node1.cpp)
+ament_auto_add_executable(node2 src/node2.cpp)
+
+# node1 と node2 に自動リンク
+rosidl_auto_generate_interfaces(TARGETS node1 node2)
+```
+
+### パターン2: TARGETS引数なし
+
+インターフェースのみ生成し、手動でリンク：
+
+```cmake
+# インターフェースのみ生成
+rosidl_auto_generate_interfaces()
+
+# 手動でリンク
+target_link_libraries(my_target
+  ${PROJECT_NAME}__rosidl_typesupport_cpp
+)
+```
+
+### パターン3: 複合（一部手動リンク）
+
+一部のターゲットは自動リンク、一部は手動リンク：
+
+```cmake
+ament_auto_add_executable(auto_linked_node src/node.cpp)
+ament_auto_add_executable(manual_linked_node src/node.cpp)
+
+# auto_linked_node のみ自動リンク
+rosidl_auto_generate_interfaces(TARGETS auto_linked_node)
+
+# manual_linked_node は手動リンク
+target_link_libraries(manual_linked_node
+  ${PROJECT_NAME}__rosidl_typesupport_cpp
+)
+```
+
+## ディレクトリ構造
+
+```
+sample_interfaces/
+├── CMakeLists.txt
+├── package.xml
+├── README.md
+├── msg/
+│   ├── Test.msg      # uint8 a, b, c, d
+│   ├── TestA.msg     # string name, int32 value, float64 timestamp
+│   └── TestB.msg     # bool flag, uint32[] data, string description
+└── src/
+    ├── node.cpp              # TARGETS引数でリンクされるノード
+    └── node_no_targets.cpp   # 手動リンクのノード
+```
+
+## 自動検出されるファイル
+
+`rosidl_auto_generate_interfaces()` は以下のパターンを自動検出：
+
+- `msg/*.msg` - メッセージ定義
+- `msg/*.idl` - IDL形式のメッセージ
+- `srv/*.srv` - サービス定義
+- `srv/*.idl` - IDL形式のサービス
+- `action/*.action` - アクション定義
+- `action/*.idl` - IDL形式のアクション
+
+## 参考リンク
+
+- [rosidl_cmake](https://github.com/ros2/rosidl) - ROS 2 インターフェース生成ツール
+- [ament_cmake_auto](https://github.com/ament/ament_cmake) - CMake自動化マクロ

--- a/sample_interfaces/msg/SensorData.idl
+++ b/sample_interfaces/msg/SensorData.idl
@@ -1,0 +1,25 @@
+// SensorData.idl - Sensor data message with validation annotations
+
+module sample_interfaces {
+  module msg {
+    struct SensorData {
+      @range(min=-40.0, max=85.0) @unit(value="celsius")
+      double temperature;
+
+      @range(min=0.0, max=100.0) @unit(value="percent")
+      double humidity;
+
+      @range(min=3.0, max=4.2) @unit(value="volt")
+      double battery_voltage;
+
+      @min(value=1)
+      uint32 sensor_id;
+
+      @range(min=0, max=255)
+      uint8 status_code;
+
+      uint64 timestamp_ns;
+      string description;
+    };
+  };
+};

--- a/sample_interfaces/package.xml
+++ b/sample_interfaces/package.xml
@@ -10,8 +10,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>rosidl_generator_validated_cpp</buildtool_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>rosidl_generator_validated_cpp</exec_depend>
 
   <depend>rclcpp</depend>
 

--- a/validated_adapter_demo/CMakeLists.txt
+++ b/validated_adapter_demo/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.14)
+project(validated_adapter_demo)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# Demo node using validated type adapter
+ament_auto_add_executable(demo_node src/demo_node.cpp)
+
+ament_auto_package()

--- a/validated_adapter_demo/package.xml
+++ b/validated_adapter_demo/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>validated_adapter_demo</name>
+  <version>0.1.0</version>
+  <description>Demo package for validated type adapter usage</description>
+  <maintainer email="hans@example.com">Hans</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>sample_interfaces</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/validated_adapter_demo/src/demo_node.cpp
+++ b/validated_adapter_demo/src/demo_node.cpp
@@ -1,0 +1,162 @@
+// Demo node for validated type adapter
+//
+// This node demonstrates the use of validated type adapters
+// generated from IDL annotations.
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+// Include the standard ROS message
+#include "sample_interfaces/msg/sensor_data.hpp"
+
+// Include the validated type adapter
+#include "sample_interfaces/msg/validated/sensor_data__validated.hpp"
+
+using namespace std::chrono_literals;
+
+// Use the type adapter
+using SensorDataValidated = sample_interfaces::msg::validated::SensorDataValidated;
+using SensorDataAdapter = rclcpp::TypeAdapter<SensorDataValidated, sample_interfaces::msg::SensorData>;
+
+class ValidatedPublisherNode : public rclcpp::Node
+{
+public:
+  ValidatedPublisherNode()
+  : Node("validated_publisher")
+  {
+    // Create publisher using the type adapter
+    publisher_ = this->create_publisher<SensorDataAdapter>("sensor_data", 10);
+
+    // Timer to publish messages
+    timer_ = this->create_wall_timer(
+      1s, std::bind(&ValidatedPublisherNode::publish_message, this));
+
+    RCLCPP_INFO(this->get_logger(), "Validated Publisher Node started");
+    RCLCPP_INFO(this->get_logger(), "Publishing valid messages every 1 second...");
+    RCLCPP_INFO(this->get_logger(), "After 5 valid messages, will attempt to publish invalid data");
+  }
+
+private:
+  void publish_message()
+  {
+    SensorDataValidated msg;
+
+    if (count_ < 5) {
+      // Publish valid data
+      msg.temperature = 25.0 + count_ * 5.0;  // 25, 30, 35, 40, 45 (all within -40 to 85)
+      msg.humidity = 50.0 + count_ * 5.0;     // 50, 55, 60, 65, 70 (all within 0 to 100)
+      msg.battery_voltage = 3.7;               // Within 3.0 to 4.2
+      msg.sensor_id = count_ + 1;              // 1, 2, 3, 4, 5 (all >= 1)
+      msg.status_code = 0;                     // Within 0 to 255
+      msg.timestamp_ns = this->now().nanoseconds();
+      msg.description = "Valid sensor reading #" + std::to_string(count_ + 1);
+
+      try {
+        publisher_->publish(msg);
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Published valid message: temp=%.1f, humidity=%.1f, voltage=%.1f, sensor_id=%u",
+          msg.temperature, msg.humidity, msg.battery_voltage, msg.sensor_id);
+      } catch (const sample_interfaces::msg::validated::ValidationError & e) {
+        RCLCPP_ERROR(this->get_logger(), "Unexpected validation error: %s", e.what());
+      }
+    } else if (count_ == 5) {
+      // Attempt to publish invalid data (temperature out of range)
+      msg.temperature = 100.0;  // INVALID: exceeds max of 85
+      msg.humidity = 50.0;
+      msg.battery_voltage = 3.7;
+      msg.sensor_id = 1;
+      msg.status_code = 0;
+      msg.timestamp_ns = this->now().nanoseconds();
+      msg.description = "Invalid temperature test";
+
+      RCLCPP_WARN(this->get_logger(), "Attempting to publish INVALID temperature (100.0 > max 85.0)...");
+
+      try {
+        publisher_->publish(msg);
+        RCLCPP_ERROR(this->get_logger(), "ERROR: Invalid message was published without validation!");
+      } catch (const sample_interfaces::msg::validated::ValidationError & e) {
+        RCLCPP_INFO(this->get_logger(), "Validation caught invalid data: %s", e.what());
+      }
+    } else if (count_ == 6) {
+      // Attempt to publish invalid data (humidity out of range)
+      msg.temperature = 25.0;
+      msg.humidity = -10.0;  // INVALID: below min of 0
+      msg.battery_voltage = 3.7;
+      msg.sensor_id = 1;
+      msg.status_code = 0;
+      msg.timestamp_ns = this->now().nanoseconds();
+      msg.description = "Invalid humidity test";
+
+      RCLCPP_WARN(this->get_logger(), "Attempting to publish INVALID humidity (-10.0 < min 0.0)...");
+
+      try {
+        publisher_->publish(msg);
+        RCLCPP_ERROR(this->get_logger(), "ERROR: Invalid message was published without validation!");
+      } catch (const sample_interfaces::msg::validated::ValidationError & e) {
+        RCLCPP_INFO(this->get_logger(), "Validation caught invalid data: %s", e.what());
+      }
+    } else if (count_ == 7) {
+      // Attempt to publish invalid data (sensor_id = 0)
+      msg.temperature = 25.0;
+      msg.humidity = 50.0;
+      msg.battery_voltage = 3.7;
+      msg.sensor_id = 0;  // INVALID: below min of 1
+      msg.status_code = 0;
+      msg.timestamp_ns = this->now().nanoseconds();
+      msg.description = "Invalid sensor_id test";
+
+      RCLCPP_WARN(this->get_logger(), "Attempting to publish INVALID sensor_id (0 < min 1)...");
+
+      try {
+        publisher_->publish(msg);
+        RCLCPP_ERROR(this->get_logger(), "ERROR: Invalid message was published without validation!");
+      } catch (const sample_interfaces::msg::validated::ValidationError & e) {
+        RCLCPP_INFO(this->get_logger(), "Validation caught invalid data: %s", e.what());
+      }
+    } else if (count_ == 8) {
+      // Demo: using is_valid() for non-throwing check
+      msg.temperature = 200.0;  // INVALID
+      msg.humidity = 50.0;
+      msg.battery_voltage = 3.7;
+      msg.sensor_id = 1;
+      msg.status_code = 0;
+
+      RCLCPP_INFO(this->get_logger(), "Demo: Using is_valid() for non-throwing validation check");
+      if (msg.is_valid()) {
+        RCLCPP_INFO(this->get_logger(), "  Message is valid");
+      } else {
+        RCLCPP_INFO(this->get_logger(), "  Message is INVALID (temperature=200.0)");
+      }
+
+      // Fix and check again
+      msg.temperature = 25.0;
+      if (msg.is_valid()) {
+        RCLCPP_INFO(this->get_logger(), "  After fix: Message is valid (temperature=25.0)");
+        publisher_->publish(msg);
+        RCLCPP_INFO(this->get_logger(), "  Published fixed message");
+      }
+    } else {
+      RCLCPP_INFO(this->get_logger(), "Demo complete. Shutting down...");
+      rclcpp::shutdown();
+      return;
+    }
+
+    count_++;
+  }
+
+  rclcpp::Publisher<SensorDataAdapter>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  size_t count_ = 0;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ValidatedPublisherNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## 概要

IDL の検証アノテーション（`@range` / `@min` / `@max` / `@unit`）を読み取り、
**publish 時に範囲検証を行う `rclcpp::TypeAdapter` クラスを自動生成**する rosidl
ジェネレータパッケージ `rosidl_generator_validated_cpp` を新規追加します。

検証は ROS メッセージへの変換時（= publish 時）に実行され、範囲外の値があれば
`ValidationError` を送出します。アプリ側は専用の検証コードを書かずに、IDL に
宣言した制約を型システム経由で強制できます。

## 主な変更

- **`rosidl_generator_validated_cpp`**（新規パッケージ）
  - empy テンプレート（`resource/validated_idl.hpp.em`）+ Python ジェネレータ
    （`get_validation_info` / `get_cpp_type` 等）+ CMake 拡張
  - `rosidl_generate_idl_interfaces` 拡張として登録され、`rosidl_generate_interfaces`
    から自動的に呼ばれる
  - 生成物: `<pkg>::msg::validated::<Msg>Validated`（`validate()` / `is_valid()` /
    `to_ros_message()` 等）と、対応する `rclcpp::TypeAdapter` 特殊化
- **`sample_interfaces`**
  - 検証アノテーション付き `msg/SensorData.idl` を追加
  - `CMakeLists.txt` / `package.xml` をジェネレータ利用形に更新
- **`validated_adapter_demo`**（新規パッケージ）
  - 有効/無効データの publish と `is_valid()` による非送出チェックの動作を示すデモノード

> なお本ブランチには先行する `ament_cmake_auto` 検証関連のコミットも含まれますが、
> 本PRの主題は上記の検証付き Type Adapter 生成機能です。

## 検証

`colcon build --packages-up-to validated_adapter_demo` で 3 パッケージとも成功。
生成ヘッダ `sample_interfaces/msg/validated/sensor_data__validated.hpp` が生成され、
`validated_adapter_demo` がそれにリンクしてコンパイルできることを確認済み。