### PR TITLE
feat: /clockを経由しない直接Clock時刻注入の検証パッケージを追加

### DIFF
--- a/clock_injection_experiments/CMakeLists.txt
+++ b/clock_injection_experiments/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.8)
+project(clock_injection_experiments)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 20)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# このパッケージはテストのみで構成され、実行ファイル/ライブラリは生成しない。
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # 著作権ヘッダを各ソースに付与していないためcopyright/cpplintリンタをスキップ
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+
+  # ament_auto_add_gtestがpackage.xmlの依存(rclcpp/rcl/rosgraph_msgs)を自動リンクする。
+
+  # --- シナリオA: rcl APIによる直接時刻注入の基本動作 ---
+  ament_auto_add_gtest(test_direct_clock_injection
+    test/test_direct_clock_injection.cpp)
+
+  # --- シナリオB: TimeSourceからdetachClockし/clockを遮断 ---
+  ament_auto_add_gtest(test_clock_isolation
+    test/test_clock_isolation.cpp
+    TIMEOUT 60)
+endif()
+
+ament_auto_package()

--- a/clock_injection_experiments/README.md
+++ b/clock_injection_experiments/README.md
@@ -1,0 +1,45 @@
+# clock_injection_experiments
+
+`/clock` トピックを経由せず、rcl API で `rclcpp::Clock` に時刻を**直接注入**できることを検証する実験パッケージ。
+
+## 背景
+
+ロックステップなシミュレーションでは、`/clock` トピック経由で配信される時刻に遅延が乗る。
+`rclcpp::Clock` の裏にある `rcl_clock_t` を直接操作すれば、トピックを介さず遅延ゼロで時刻を反映できる。
+本パッケージはその実現可能性を gtest で確認する。
+
+## 仕組み
+
+`rclcpp::Clock(RCL_ROS_TIME)` から `get_clock_handle()` で `rcl_clock_t*` を取り出し、
+rcl の公開 API で時刻を注入する。
+
+```cpp
+auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+rcl_clock_t * handle = clock->get_clock_handle();
+
+rcl_enable_ros_time_override(handle);          // override を有効化（必須）
+rcl_set_ros_time_override(handle, time_ns);    // 時刻を直接注入
+
+clock->now();  // 注入値がそのまま返る（遅延ゼロ）
+```
+
+## テスト
+
+| テスト | 内容 |
+| --- | --- |
+| `test_direct_clock_injection` | rcl API による直接注入の基本動作。`now()` が注入値と完全一致（遅延ゼロ）で返ること、複数回注入・巻き戻しが都度反映されること、override 有効化が必須であること、`RCL_ROS_TIME` 以外は注入不可なことを確認。 |
+| `test_clock_isolation` | `TimeSource` に attach した Clock を `detachClock()` で `/clock` から引き剥がす。`/clock` 経由更新が効くことを確認後、detach → 直接注入し、その後 `/clock` を別の値で発行しても `now()` が注入値のまま影響を受けないことを確認。 |
+
+## 確認できた知見
+
+- `detachClock()` は override を無効化しない。detach 後も `ros_time_is_active()` は `true` のままで、直接注入が即有効。
+- `TimeSource` に attach していない `RCL_ROS_TIME` Clock は `/clock` の影響を受けず、注入だけで動く（ロックステップ用途の本命挙動）。
+- `TimeSource` は `use_clock_thread=false` にして自前 executor の spin に直列化すると、直接注入とのスレッド競合を避けられる。
+
+## ビルドとテスト
+
+```bash
+colcon build --packages-select clock_injection_experiments
+colcon test --packages-select clock_injection_experiments
+colcon test-result --all --verbose
+```

--- a/clock_injection_experiments/package.xml
+++ b/clock_injection_experiments/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>clock_injection_experiments</name>
+  <version>0.0.0</version>
+  <description>rcl APIを用いて/clockトピックを経由せずrclcpp::Clockへ時刻を直接注入する検証パッケージ</description>
+  <maintainer email="pythagora.yoshimoto@gmail.com">hans</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rcl</depend>
+  <depend>rosgraph_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/clock_injection_experiments/test/test_clock_isolation.cpp
+++ b/clock_injection_experiments/test/test_clock_isolation.cpp
@@ -1,0 +1,107 @@
+// TimeSourceにattachしたClockをdetachClockで/clockから引き剥がし、
+// 以降は直接注入のみが効き/clock発行の影響を受けないことを検証する。
+//
+// 検証の狙い(ロックステップ用途):
+//   1. use_sim_time=true + TimeSource + attachClockで/clock経由の更新が効くことを確認。
+//   2. detachClock後にrcl APIで時刻を直接注入する。
+//   3. その後/clockを別の値で発行してもnow()が直接注入値のまま影響を受けないことを確認。
+
+#include <gtest/gtest.h>
+#include <rcl/time.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time_source.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
+
+namespace
+{
+
+using namespace std::chrono_literals;
+
+class ClockIsolationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(ClockIsolationTest, ClockTopicDrivesThenIsolatedAfterDetach)
+{
+  // use_sim_time=trueでノードを生成(TimeSourceがoverrideを有効化する)。
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({rclcpp::Parameter("use_sim_time", true)});
+  auto node = std::make_shared<rclcpp::Node>("clock_isolation_test_node", options);
+
+  auto ros_clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+
+  // use_clock_thread=falseで内部スレッドを無効化し、自前executorのspinに直列化する
+  // (直接注入とのスレッド競合を避ける)。
+  rclcpp::TimeSource time_source(node, rclcpp::ClockQoS(), /*use_clock_thread=*/false);
+  time_source.attachClock(ros_clock);
+
+  // /clockを発行する側のノード。
+  auto pub_node = std::make_shared<rclcpp::Node>("test_clock_publisher");
+  auto clock_pub =
+    pub_node->create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::ClockQoS());
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.add_node(pub_node);
+
+  // 指定値を/clockに発行し、ros_clockへ反映されるまでspinしながら待つ。
+  auto publish_and_wait = [&](int64_t ns) -> bool {
+      rosgraph_msgs::msg::Clock msg;
+      msg.clock = rclcpp::Time(ns, RCL_ROS_TIME);
+      const auto deadline = std::chrono::steady_clock::now() + 5s;
+      while (std::chrono::steady_clock::now() < deadline) {
+        clock_pub->publish(msg);
+      // spin_someがイベント到着待ちを兼ねるため、別途のsleepは不要。
+        executor.spin_some(50ms);
+        if (ros_clock->now().nanoseconds() == ns) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+  // --- ステップ1: /clock経由でros_clockが更新されることを確認 ---
+  ASSERT_TRUE(ros_clock->ros_time_is_active());
+  const int64_t kTimeViaTopic = 5'000'000'000LL;  // 5s
+  ASSERT_TRUE(publish_and_wait(kTimeViaTopic)) << "/clock経由でClockが更新されなかった";
+  EXPECT_EQ(ros_clock->now().nanoseconds(), kTimeViaTopic);
+
+  // --- ステップ2: TimeSourceからClockを引き剥がす ---
+  time_source.detachClock(ros_clock);
+  // detachしてもoverride自体は無効化されない(TimeSourceはdisableを呼ばない)。
+  EXPECT_TRUE(ros_clock->ros_time_is_active());
+
+  // --- ステップ3: rcl APIで時刻を直接注入 ---
+  // ステップ2でoverrideが有効なまま(detachはdisableしない)なので、enableの再確認は不要。
+  // use_clock_thread=falseかつ自前spinと同一スレッドで注入するためロックも不要。
+  rcl_clock_t * handle = ros_clock->get_clock_handle();
+  const int64_t kInjectedTime = 42'000'000'000LL;  // 42s
+  ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(handle, kInjectedTime))
+    << rcl_get_error_string().str;
+  EXPECT_EQ(ros_clock->now().nanoseconds(), kInjectedTime);
+
+  // --- ステップ4: /clockを別値で発行しても直接注入値が保持されること ---
+  const int64_t kNoiseTime = 99'000'000'000LL;  // 99s
+  rosgraph_msgs::msg::Clock noise;
+  noise.clock = rclcpp::Time(kNoiseTime, RCL_ROS_TIME);
+  for (int i = 0; i < 3; ++i) {
+    clock_pub->publish(noise);
+    executor.spin_some(50ms);
+  }
+  EXPECT_EQ(ros_clock->now().nanoseconds(), kInjectedTime) << "detach後に/clockがClockへ漏れている";
+}
+
+}  // namespace

--- a/clock_injection_experiments/test/test_direct_clock_injection.cpp
+++ b/clock_injection_experiments/test/test_direct_clock_injection.cpp
@@ -1,0 +1,104 @@
+// rcl APIを用いてrclcpp::Clockへ/clockトピックを経由せず時刻を直接注入する基本動作の検証。
+//
+// 検証の狙い:
+//   rclcpp::Clock(RCL_ROS_TIME)の裏にあるrcl_clock_tをget_clock_handle()で取得し、
+//   rcl_enable_ros_time_override + rcl_set_ros_time_overrideで時刻を注入すると、
+//   now()が注入値と完全一致(遅延ゼロ)で返ることを確認する。
+
+#include <gtest/gtest.h>
+#include <rcl/time.h>
+
+#include <cstdint>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <vector>
+
+namespace
+{
+
+class DirectClockInjectionTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+  }
+};
+
+// override未有効のRCL_ROS_TIME clockに対し、enable後に時刻注入するとnow()へ即時反映される。
+TEST_F(DirectClockInjectionTest, InjectOnceReflectsImmediately)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * handle = clock->get_clock_handle();
+
+  // override有効化前はROS時刻はアクティブでない。
+  EXPECT_FALSE(clock->ros_time_is_active());
+
+  ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(handle)) << rcl_get_error_string().str;
+
+  // rclcpp側ラッパー(ros_time_is_active)とrcl側getterの両層で有効化を確認する。
+  EXPECT_TRUE(clock->ros_time_is_active());
+  bool enabled = false;
+  ASSERT_EQ(RCL_RET_OK, rcl_is_enabled_ros_time_override(handle, &enabled))
+    << rcl_get_error_string().str;
+  EXPECT_TRUE(enabled);
+
+  const rcl_time_point_value_t injected = 1234567890LL;
+  ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(handle, injected)) << rcl_get_error_string().str;
+
+  // 遅延ゼロ・完全一致(int64比較)で注入値が反映される。
+  EXPECT_EQ(clock->now().nanoseconds(), injected);
+
+  // rcl側のgetterとも一致する。
+  rcl_time_point_value_t got = 0;
+  ASSERT_EQ(RCL_RET_OK, rcl_clock_get_now(handle, &got)) << rcl_get_error_string().str;
+  EXPECT_EQ(got, injected);
+}
+
+// 複数回の注入が都度反映され、巻き戻し(減少)も含めて反映されることを確認する。
+TEST_F(DirectClockInjectionTest, MultipleInjectionsEachReflected)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rcl_clock_t * handle = clock->get_clock_handle();
+
+  ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(handle)) << rcl_get_error_string().str;
+
+  const std::vector<rcl_time_point_value_t> sequence = {
+    1'000'000'000LL,      // 1s
+    2'000'000'000LL,      // 2s
+    9'000'000'000'000LL,  // 9000s (大きい値)
+    500'000'000LL,        // 0.5s (巻き戻し)
+  };
+
+  for (const auto value : sequence) {
+    ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(handle, value)) << rcl_get_error_string().str;
+    EXPECT_EQ(clock->now().nanoseconds(), value);
+  }
+}
+
+// override未有効ではROS時刻はアクティブにならず、注入のためにはenableが必須であることを固定化する。
+TEST_F(DirectClockInjectionTest, NowWithoutOverrideIsNotActive)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+
+  EXPECT_FALSE(clock->ros_time_is_active());
+  // enableせずにnow()を呼んでもクラッシュしない(バッキングのシステム時刻が返る)。
+  EXPECT_NO_THROW((void)clock->now());
+}
+
+// RCL_ROS_TIME以外のクロックはoverrideできないことを確認する(落とし穴の固定化)。
+TEST_F(DirectClockInjectionTest, NonRosTimeClockCannotBeOverridden)
+{
+  auto clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
+  rcl_clock_t * handle = clock->get_clock_handle();
+
+  EXPECT_NE(RCL_RET_OK, rcl_enable_ros_time_override(handle));
+  // エラー状態を残すと後続の判定に影響するためクリアする。
+  rcl_reset_error();
+}
+
+}  // namespace


### PR DESCRIPTION
## 概要

ロックステップシミュレーションにおいて `/clock` トピック経由の時刻には遅延が乗るという課題に対し、**rcl API で `rclcpp::Clock` へ時刻を直接注入する**手法の実現可能性を検証する実験パッケージ `clock_injection_experiments` を追加します。

`rclcpp::Clock(RCL_ROS_TIME)` から `get_clock_handle()` で `rcl_clock_t*` を取り出し、`rcl_enable_ros_time_override` + `rcl_set_ros_time_override` を使うことで、`/clock` を介さず遅延ゼロの時刻を `now()` に反映できることを gtest で確認しています。

## テスト内容

| テスト | 検証内容 |
| --- | --- |
| `test_direct_clock_injection` | 直接注入の基本動作。`now()` が注入値と完全一致（遅延ゼロ）で返ること、複数回注入・巻き戻しの反映、override 有効化の必須性、`RCL_ROS_TIME` 以外は注入不可なことを確認 |
| `test_clock_isolation` | `TimeSource` から `detachClock()` で `/clock` を遮断。`/clock` 経由更新が効くことを確認後、detach → 直接注入し、その後 `/clock` を別値で発行しても `now()` が注入値のまま影響を受けないことを確認 |

## 確認できた知見

- `detachClock()` は override を無効化しない。detach 後も `ros_time_is_active()` は `true` のままで直接注入が即有効。
- `TimeSource` に attach していない `RCL_ROS_TIME` Clock は `/clock` の影響を受けず、注入だけで動作する（ロックステップ用途の本命挙動）。
- `TimeSource` を `use_clock_thread=false` にして自前 executor の spin に直列化すると、直接注入とのスレッド競合を避けられる。

## 動作確認

`colcon build` / `colcon test` ともに成功。gtest 5 ケース全 PASS、lint（uncrustify 等）も PASS。

\`\`\`
colcon build --packages-select clock_injection_experiments
colcon test --packages-select clock_injection_experiments
\`\`\`