### PR TITLE
fix: CIのROSディストロをrolling→kiltedに変更

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rosdistro: [rolling]
+        rosdistro: [jazzy]
         rosidl_branch: [feature/rosidl_auto_generate_interfaces]
     steps:
       - name: suppress warnings

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rosdistro: [jazzy]
+        rosdistro: [kilted]
         rosidl_branch: [feature/rosidl_auto_generate_interfaces]
     steps:
       - name: suppress warnings


### PR DESCRIPTION
## 背景

`build test` ワークフローが直近すべて `Run rosdep install` ステップで失敗していた（例: [run 26609828426](https://github.com/HansRobo/ros2_sandbox/actions/runs/26609828426)）。

**根本原因**: ROS Rolling が Ubuntu 24.04 (Noble) → 26.04 (Resolute) へ移行した（2026-04-23 の Rolling sync）。

- rolling の `distribution.yaml` は対象 Ubuntu を `resolute` のみに変更し noble を削除
- 公式 `ros:rolling` イメージはまだ noble ベース（resolute 版イメージは未公開）
- → noble 上で `rosdep install --rosdistro rolling` を実行すると `std_msgs` / `rclcpp` 等すべての ROS キーが解決不能

## 変更

matrix の `rosdistro` を `rolling` → `kilted` に切り替え。`container` / `rosdep` / `setup.sh` はすべて `matrix.rosdistro` 参照のため連動。

### kilted を選んだ理由

| 対象 | rosidl_runtime_cpp | `ament_cmake_ros_core` | Ubuntu |
|---|---|---|---|
| rosidl フィーチャーブランチ | 5.1.1（rolling ベース） | 必須 | — |
| jazzy | 4.6.7 | **なし** | noble |
| kilted | 4.9.6 | あり | noble |
| rolling | 5.3.0 | あり | resolute (26.04, イメージ未公開) |

- まず jazzy を試したが、rolling ベースの rosidl ソースが必須とする `ament_cmake_ros_core` が jazzy の rosdistro に存在せず rosdep install で失敗
- `ament_cmake_ros_core` は kilted 世代で導入されたパッケージで kilted/rolling にのみ存在
- kilted は noble ベースで利用可能な `ros:kilted` イメージがあり、rosidl バージョンも 4.9.6 とフィーチャーブランチに近い

## 検証結果

PR の CI（[run 26636621484](https://github.com/HansRobo/ros2_sandbox/actions/runs/26636621484)）で全ステップ成功:
- ✅ Run rosdep install
- ✅ Build（懸念していた rosidl バージョン不整合は発生せず）
- ✅ Verify sample_interfaces generated files / executables